### PR TITLE
Update reference guide to mention Event.detail

### DIFF
--- a/src/documentation/reference-guide/1.10/dojo/on.rst
+++ b/src/documentation/reference-guide/1.10/dojo/on.rst
@@ -85,6 +85,8 @@ event    Object This is an object with the properties of the event to be dispatc
                 * cancelable - This indicates that the event's default action can be cancelled. The default action is 
                   cancelled by a listener by calling ``event.preventDefault()``. The emit method does not perform any 
                   default action, it returns a value allowing the calling code to perform any default action.
+                * detail - When an event is emitted using ``widget.emit()``, this object is added and contains useful
+                  information such as a reference to the widget instance that emitted the event.
 ======== ====== =======================================================================================================
 
 ``emit()`` returns the event object unless the event is cancelable and is cancelled by one of the listeners, in which 


### PR DESCRIPTION
Event objects emitted using `_WidgetBase.emit` have an extra object on them that is undocumented. We should mention this somewhere in our documentation, and this seemed like the most appropriate place.