### PR TITLE
Fix 'Start Contributing' link

### DIFF
--- a/src/community/index.ejs
+++ b/src/community/index.ejs
@@ -79,7 +79,7 @@
 
 							<p>For more on CLAs, read Alex Russell's <a href="http://alex.dojotoolkit.org/2008/06/why-do-i-need-to-sign-this/">Why Do I Need to Sign This?</a>.</p>
 
-							<div class="becomeContributor"><a href="https://github.com/dojo/core/blob/master/CONTRIBUTING.md"><span class="button">Start Contributing</span></a></div>
+							<div class="becomeContributor"><a href="https://github.com/dojo/meta/blob/master/CONTRIBUTING.md"><span class="button">Start Contributing</span></a></div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
https://github.com/dojo/core/blob/master/CONTRIBUTING.md points the reader to https://github.com/dojo/meta/blob/master/CONTRIBUTING.md so let's go there directly.