### PR TITLE
new: Updates to roadmap statuses.

### DIFF
--- a/src/_partials/ui/roadmapCard.ejs
+++ b/src/_partials/ui/roadmapCard.ejs
@@ -19,10 +19,6 @@
 		<div class="taskbar">
 			<div class="controls">
 
-				<% if(specUrl) { %>
-					<a href="<%= specUrl %>" target="_blank"><span class="icon-spec icon"></span></a>
-				<% }  %>
-
 				<% if(githubUrl) { %>
 					<a href="<%= githubUrl %>" target="_blank">
 				<% } else { %>
@@ -30,6 +26,10 @@
 				<% } %>
 						<span class="icon-github icon"></span>
 					</a>
+
+				<% if(specUrl) { %>
+				<a href="<%= specUrl %>" target="_blank"><span class="icon-spec icon"></span></a>
+				<% }  %>
 			</div>
 
 			<div class="tag <%= status %>">#<%= status %></div>

--- a/src/community/roadmap/index.ejs
+++ b/src/community/roadmap/index.ejs
@@ -117,7 +117,7 @@
 
 					<h3 class="subTitle alt">Contributing Code</h3>
 
-					<p>When development starts on a package a link to the github repo for the package will be posted. To contribute follow the guide to <a href="https://github.com/dojo/dojo/blob/master/CONTRIBUTING.md#submitting-a-pull-request">Submitting a Pull Request</a>.</p>
+					<p>When development starts on a package a link to the github repo for the package will be posted. To contribute, follow the guide to <a href="https://github.com/dojo/dojo/blob/master/CONTRIBUTING.md#submitting-a-pull-request">Submitting a Pull Request</a>.</p>
 
 					<p>First things first though, if you're not a contributor we'll need for you to become one.</p>
 

--- a/src/community/roadmap/packages.json
+++ b/src/community/roadmap/packages.json
@@ -1,17 +1,10 @@
 {
 	"packages": [
 		{
-			"title":"core",
-			"description":"A set of language helpers, utility functions, and classes for writing TypeScript applications.  Includes APIs for feature detection, asynchronous and streaming operations, basic event handling, and making HTTP requests.",
-			"status":"alpha",
-			"specUrl": "https://drive.google.com/open?id=1E_nh2Cq0E6LJCXPvL2mbPujrpyBIXSXTr2epwlPVABU&authuser=0",
-			"githubUrl": "https://github.com/dojo/core"
-		},
-		{
 			"title":"actions",
-			"description": "A command like library for Dojo 2 Applications.",
+			"description": "A command like library for Dojo 2 applications.",
 			"specUrl": "",
-			"status":"planning",
+			"status":"alpha",
 			"githubUrl": "https://github.com/dojo/actions"
 		},
 		{
@@ -21,10 +14,9 @@
 			"status":"alpha",
 			"githubUrl": "https://github.com/dojo/app"
 		},
-
 		{
 			"title":"cli",
-			"description": "This package provides a CLI for creating Dojo 2 Applications.",
+			"description": "A CLI (command line interface) for creating Dojo 2 applications.",
 			"specUrl": "",
 			"status":"alpha",
 			"githubUrl": "https://github.com/dojo/cli"
@@ -37,11 +29,11 @@
 			"githubUrl": "https://github.com/dojo/compose"
 		},
 		{
-			"title":"crypto",
-			"description":"User-friendly, cross-platform, extensible cryptographic API. Initially includes a set of hashing and signing algorithms to support common use cases like OAuth and AWS request validation. crypto makes working with cryptographic algorithms easier by providing a consistent cross-platform API for accessing native cryptographic functionality.",
-			"status":"alpha",
-			"specUrl": "https://drive.google.com/open?id=1c6LM02gzoXVVPNb4yqKOZc1cMop1wnQGOVYGyJMUxLA&authuser=0",
-			"githubUrl": "https://github.com/dojo/crypto"
+			"title":"core",
+			"description":"A set of language helpers, utility functions, and classes for writing TypeScript applications.  Includes APIs for feature detection, asynchronous and streaming operations, basic event handling, and making HTTP requests.",
+			"status":"beta",
+			"specUrl": "https://drive.google.com/open?id=1E_nh2Cq0E6LJCXPvL2mbPujrpyBIXSXTr2epwlPVABU&authuser=0",
+			"githubUrl": "https://github.com/dojo/core"
 		},
 		{
 			"title":"dom",
@@ -51,15 +43,8 @@
 			"githubUrl": "https://github.com/dojo/dom"
 		},
 		{
-			"title":"grunt-dojo2",
-			"description": "A package of Grunt tasks and configuration to use with Dojo 2 Packages.",
-			"specUrl": "",
-			"status":"alpha",
-			"githubUrl": "https://github.com/dojo/grunt-dojo2"
-		},
-		{
 			"title":"has",
-			"description":"This package provides an API for expressing feature detection to allow alphaelopers to branch code based upon the detected features.",
+			"description":"This package provides an API for expressing feature detection to allow developers to branch code based upon the detected features.",
 			"specUrl":"",
 			"status":"alpha",
 			"githubUrl": "https://github.com/dojo/has"
@@ -72,16 +57,9 @@
 			"githubUrl": "https://github.com/dojo/i18n/"
 		},
 		{
-			"title":"io",
-			"description":"An API for working with input/ouput (io) operations including filesystem access, sockets, workers, and other APIs as available.",
-			"status":"planning",
-			"specUrl": "https://drive.google.com/open?id=1nU6bBptUJSlO38iZR6sT7fOj5KOCNy8Ux181Yeevzgs&authuser=0",
-			"githubUrl": ""
-		},
-		{
 			"title":"loader",
 			"description":"A minimal bootstrap for TypeScript and JavaScript libraries that loads modules in AMD, CJS, and eventually ES2015 formats.",
-			"status":"alpha",
+			"status":"beta",
 			"specUrl": "https://drive.google.com/open?id=1-gbawq5nhi1GuYuVMoTJBFAzESaqgYKlS_aLzHzaAXs&authuser=0",
 			"githubUrl": "https://github.com/dojo/loader"
 		},
@@ -96,7 +74,7 @@
 			"title":"shim",
 			"description":"Targeted at providing function shims for ECMAScript 6 and beyond targeted at ECMAScript 5. It is different other solutions of shimming or polyfilling functionality, in that it does not provide the functionality via augmenting the built in classes in the global namespace.",
 			"specUrl":"",
-			"status":"alpha",
+			"status":"beta",
 			"githubUrl": "https://github.com/dojo/shim"
 		},
 		{
@@ -112,14 +90,6 @@
 			"specUrl":"",
 			"status":"alpha",
 			"githubUrl": "https://github.com/dojo/widgets"
-		},
-		{
-			"title":"examples",
-			"description": "This repository contains example applications built using Dojo 2.",
-			"specUrl": "",
-			"status":"alpha",
-			"githubUrl": "https://github.com/dojo/examples"
 		}
-
 	]
 }


### PR DESCRIPTION
Updated roadmap status for various packages.
Removed `io` and `crypto` packages from list.

Tweeked roadmap cards to have github link first (because is not optional) and proposal second (because its optional) - so is consistent across all cards  - found I was scanning for links.

Fixed typo on roadmap page.
