### PR TITLE
community updates

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,7 +45,7 @@ module.exports = function(grunt){
 			facebook: 'https://www.facebook.com/groups/4375511291/',
 			github: 'https://github.com/dojo',
 			googlePlus: 'https://plus.google.com/106701567946037375891/posts',
-			irc: 'http://irc.lc/freenode/dojo/t4nk@@@',
+			irc: 'http://irc.lc/freenode/dojo/dtk_web_client@@@',
 			mailingList: 'http://mail.dojotoolkit.org/mailman/listinfo/dojo-interest',
 			stackoverflow: 'http://stackoverflow.com/questions/tagged/dojo',
 			twitter: 'http://twitter.com/dojo',

--- a/config.js
+++ b/config.js
@@ -46,6 +46,7 @@ module.exports = function(grunt){
 			github: 'https://github.com/dojo',
 			googlePlus: 'https://plus.google.com/106701567946037375891/posts',
 			irc: 'http://irc.lc/freenode/dojo/dtk_web_client@@@',
+			gitter: 'https://gitter.im/dojo/dojo2',
 			mailingList: 'http://mail.dojotoolkit.org/mailman/listinfo/dojo-interest',
 			stackoverflow: 'http://stackoverflow.com/questions/tagged/dojo',
 			twitter: 'http://twitter.com/dojo',

--- a/src/_partials/ui/helpSupport.ejs
+++ b/src/_partials/ui/helpSupport.ejs
@@ -5,6 +5,9 @@
 	<a href="<%= url.ext.irc %>" class="icon irc">#dojo on IRC</a>
 </div>
 <div class="medium-2 columns">
+	<a href="<%= url.ext.gitter %>" class="icon irc">#dojo2 on gitter</a>
+</div>
+<div class="medium-2 columns">
 	<a href="<%= url.ext.stackoverflow %>" class="icon stackoverflow">Stack Overflow</a>
 </div>
 <div class="medium-2 columns">


### PR DESCRIPTION
1. rename t4nk@@@ to dtk_web_client@@@ for clarity
   
   folks coming into the irc room with t4nk123 and t4nk323 is confusing. i think it would make more sense to folks in the room to know the person is using the [community link](https://dojotoolkit.org/community/) and have a more explicit name like dtk_web_client@@@\
2. add gitter link closes #20
3. remove [dojo meeting](22)
