### PR TITLE
point site to Discourse instead of mailing list, and GitHub instead of trac, added Gitter

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,14 +38,14 @@ module.exports = function(grunt){
 
 		//External
 		ext: {
-			bugTracker: 'https://bugs.dojotoolkit.org/',
+			bugTracker: 'https://github.com/dojo/dojo',
 			commercialSupport: 'http://www.sitepen.com/support/index.html',
 			facebook: 'https://www.facebook.com/groups/4375511291/',
 			github: 'https://github.com/dojo',
 			googlePlus: 'https://plus.google.com/106701567946037375891/posts',
 			irc: 'http://irc.lc/freenode/dojo/dtk_web_client@@@',
 			gitter: 'https://gitter.im/dojo/dojo',
-			mailingList: 'http://mail.dojotoolkit.org/mailman/listinfo/dojo-interest',
+			mailingList: 'https://discourse.dojo.io/c/dojo1',
 			stackoverflow: 'http://stackoverflow.com/questions/tagged/dojo',
 			twitter: 'http://twitter.com/dojo',
 			jsFoundation: 'https://js.foundation/',

--- a/src/_partials/ui/helpSupport.ejs
+++ b/src/_partials/ui/helpSupport.ejs
@@ -1,11 +1,14 @@
-<div class="medium-2 columns medium-offset-1">
-	<a href="<%= url.ext.mailingList %>" class="icon mailingList">Dojo Mailing List</a>
+<div class="medium-2 columns medium-offset-0">
+	<a href="<%= url.ext.mailingList %>" class="icon mailingList">Dojo on Discourse</a>
 </div>
 <div class="medium-2 columns">
 	<a href="<%= url.ext.irc %>" class="icon irc">#dojo on IRC</a>
 </div>
 <div class="medium-2 columns">
 	<a href="<%= url.ext.gitter %>" class="icon irc">Dojo on Gitter</a>
+</div>
+<div class="medium-2 columns">
+	<a href="<%= url.ext.bugTracker %>" class="icon bug">Dojo on GitHub</a>
 </div>
 <div class="medium-2 columns">
 	<a href="<%= url.ext.stackoverflow %>" class="icon stackoverflow">Stack Overflow</a>


### PR DESCRIPTION
Part of my scour for the bugs.dojotoolkit.org.  I added a link to GitHub with the old bugs icon.  Also swapped out the mailing list link for Discourse, added Gitter for live chat.

Trac is currently disabled for new issues, and the landing page points everyone to the various repos on GitHub: https://bugs.dojotoolkit.org/

See image below if you don't want to load the entire site locally.

![dojotoolkit-updates](https://user-images.githubusercontent.com/3740674/41828669-80413d04-77eb-11e8-82e2-0c084527502e.png)
