### PR TITLE
security email addition

### DIFF
--- a/src/community/index.ejs
+++ b/src/community/index.ejs
@@ -73,6 +73,9 @@
 							<p>For more on CLAs, read Alex Russell's <a href="http://alex.dojotoolkit.org/2008/06/why-do-i-need-to-sign-this/">Why Do I Need to Sign This?</a>.</p>
 
 							<div class="becomeContributor"><a href="https://github.com/dojo/meta/blob/master/CONTRIBUTING.md"><span class="button">Start Contributing</span></a></div>
+							
+
+							<p>To report vulnerabilities in Dojo Toolkit, please email us: dojo-security@dojotoolkit.org</p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
I tacked this onto the bottom of the community page.  Google is pretty good about filtering spam to groups so I'm not overly worried about garbage coming in.  If you don't like the bare email, I can probably set up a GSuite Form for submissions.  